### PR TITLE
fix: Use `response.elapsed.total_seconds()` to measure response time

### DIFF
--- a/test.py
+++ b/test.py
@@ -1,14 +1,10 @@
 # test.py
-import requests
 import schemathesis
-import timeit
 
 schema = schemathesis.from_path('./todo.yaml')
 schema.base_url = 'http://localhost:8080'
 
 @schema.parametrize()
 def test_time(case):
-    start = timeit.timeit()
-    case.call()
-    end = timeit.timeit()
-    assert (end-start) < 1
+    response = case.call()
+    assert response.elapsed.total_seconds() < 1


### PR DESCRIPTION
Hello @NateLove !

This patch adds using built-in response time to avoid manual calculations. Also, `timeit.timeit` serves a slightly different purpose - it runs a statement that is passed as the first argument for N iterations (1000000 by default) and returns the total time spent on it. Alternatively `time.time` could be used:

```
start = time.time()
case.call()
end = time.time()
```

I am really happy to see you using Schemathesis and I'd appreciate any feedback :) Let me know if I can provide some support with Schemathesis :)

Cheers!